### PR TITLE
Ensure links can be clicked on

### DIFF
--- a/theme/stylesheets/website/body.less
+++ b/theme/stylesheets/website/body.less
@@ -31,11 +31,11 @@
             .page-inner {
                 max-width: 1200px;
                 margin: 0px auto;
-                padding: 20px 0px 40px 0px;
+                padding: 20px 0px 40px 90px;
 
                 section {
                     margin: 0px 0px;
-                    padding: 5px 15px;
+                    padding: 5px 15px 5px 0;
 
                     background: @page-background;
                     border-radius: 2px;


### PR DESCRIPTION
Because the right-left links are in the way, some links in the page-inner element cannot be clicked.

Move the page-inner element's contents away from the right-left link.

Also, remove the padding to the left, because the parent has already been padded.

<img width="621" alt="screen shot 2015-09-02 at 14 28 29" src="https://cloud.githubusercontent.com/assets/193115/9631098/f1c03e94-517e-11e5-871e-f068f902e7ec.png">

<img width="635" alt="screen shot 2015-09-02 at 14 29 11" src="https://cloud.githubusercontent.com/assets/193115/9631104/01a3a026-517f-11e5-90d8-bf9752477f1c.png">
