### PR TITLE
Fixes typo in fromEventPattern example

### DIFF
--- a/content/observable/observable_methods/fromeventpattern.md
+++ b/content/observable/observable_methods/fromeventpattern.md
@@ -70,7 +70,7 @@ var source = Rx.Observable.fromEventPattern(
 );
 
 var subscription = source.subscribe(
-    function (x) {
+    function (result) {
         console.log('Next: ' + result);
     },
     function (err) {


### PR DESCRIPTION
Just a simple renaming that would otherwise prevent the sample from working.

Great work btw!