### PR TITLE
Observer is type of Subscriber , doesn't have onNext, onCompleted pro…

### DIFF
--- a/content/getting_started_with_rxjs/creating_and_querying_observable_sequences/creating_and_subscribing_to_simple_observable_sequences.md
+++ b/content/getting_started_with_rxjs/creating_and_querying_observable_sequences/creating_and_subscribing_to_simple_observable_sequences.md
@@ -23,8 +23,8 @@ In this example, we will simply yield a single value of 42 and then mark it as c
 ```js
 var source = Rx.Observable.create(observer => {
   // Yield a single value and complete
-  observer.onNext(42);
-  observer.onCompleted();
+  observer.next(42);
+  observer.complete();
 
   // Any cleanup logic might go here
   return () => console.log('disposed')


### PR DESCRIPTION
…totype method

 `Observable.create` passes a `Subscriber` object to it's argument function . And it doesn't have onNext , onCompleted method . You need to use `next` and `complete` instead . Dont know why it's wrong everywhere all over the internet. Following is a perfectly working code snippet using `"rxjs": "5.0.0-beta.2",`

```javaScript
import {Component} from 'angular2/core'; 
import { Observable } from 'rxjs/Rx';

@Component({
	template: `
    <h2>Promise Vs Observable</h2>
    <p> Observable next: {{observableOutput}} </p>`
})
export class ObservableExample {
	observableOutput: String;

	ngOnInit() { 
		this.implementObservable(); 
	}

	implementObservable() {
		let source = Observable.create((observer) => {
			setTimeout(() => observer.next('Observable works'), 1000);
		});
		source.subscribe((res: String) => this.observableOutput = res);
	}
}
```